### PR TITLE
Fixes extended grant type callback function

### DIFF
--- a/lib/grant.js
+++ b/lib/grant.js
@@ -319,7 +319,7 @@ function useExtendedGrant (done) {
     if (!supported) {
       return done(error('invalid_request',
         'Invalid grant_type parameter or parameter missing'));
-    } else if (!user || user.id === undefined) {
+    } else if (!user) {
       return done(error('invalid_request', 'Invalid request.'));
     }
 


### PR DESCRIPTION
Relates to the 'user' argument for the extendedGrant callback. The docs indicate an object is required but supplying one yields 'invalid input syntax for integer: "{"id":123}". Supplying an integer errors due to 'user.id == undefined'.

This fix brings the extendedGrant callback in line with the other callbacks that expect user to be an integer. (Although the example pSQL schema creates the user ids as uuids?)
